### PR TITLE
make repository work with up to date deno version

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,7 @@
-import * as deno from "deno";
-
 const readFile = async (file: string, type?: string) => {
   const types = type || 'utf-8'
   return new TextDecoder(types).decode(
-    await deno.readFile(file)
+    await Deno.readFile(file)
   )
 }
 


### PR DESCRIPTION
Current version fails with `relative import path "deno" not prefixed with / or ./ or ../ Imported from "file:///b/ls/dbpedia_import/mapping_generator.js"` - there is now a global `Deno`  object which exposes the `readFile` function. This pull request makes use of it.
Regards